### PR TITLE
Improve ro-crate types exposure

### DIFF
--- a/.changeset/upset-walls-fold.md
+++ b/.changeset/upset-walls-fold.md
@@ -1,0 +1,5 @@
+---
+"ro-crate-zip-explorer": patch
+---
+
+Expose internal RO-Crate types to library consumers

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
   "dependencies": {
     "jszip": "^3.10.1",
     "pako": "^2.1.0",
-    "ro-crate": "^3.4.1"
+    "ro-crate": "^3.4.6"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { ROCrateZipExplorer, type ROCrateZip } from "./explorer.js";
 export type { AnyZipEntry, ZipDirectoryEntry, ZipFileEntry } from "./interfaces.js";
+export type { Entity as ROCrateEntity, ROCrateReadOnlyView } from "./types/ro-crate-interfaces.js";

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,11 +1,11 @@
-import type { ROCrate } from "ro-crate";
+import type { ROCrateReadOnlyView } from "./types/ro-crate-interfaces.js";
 
 /**
  * Represents a Zip archive containing an RO-Crate manifest.
  */
 export interface ROCrateZip {
   /** The RO-Crate metadata object. */
-  readonly crate: ROCrate;
+  readonly crate: ROCrateReadOnlyView;
 
   /** The ZIP archive and its contents. */
   readonly zip: ZipArchive;

--- a/src/types/ro-crate-interfaces.ts
+++ b/src/types/ro-crate-interfaces.ts
@@ -1,0 +1,128 @@
+/**
+ * This interface represents an immutable read-only view of an RO-Crate.
+ *
+ * It provides access to the context, graph, and metadata of the RO-Crate.
+ * It also provides methods for resolving context terms, getting entity definitions,
+ * getting entities from the graph, and checking if an entity exists in the graph.
+ */
+export interface ROCrateReadOnlyView {
+  /**
+   * The context part of the crate. An alias for '@context'.
+   * This returns the original context information.
+   */
+  readonly context: unknown[];
+
+  /**
+   * An array of all nodes in the graph. An alias for '@graph'
+   */
+  readonly graph: Entity[];
+
+  /**
+   * The number of nodes in the graph
+   */
+  readonly graphSize: number;
+
+  /**
+   * The metadata file entity.
+   * This is the entity that represents the metadata file of the RO Crate.
+   */
+  readonly metadataFileEntity: Entity;
+
+  /**
+   * The root dataset entity. An alias for the entity with the same id as the rootId.
+   */
+  readonly rootDataset: Entity;
+
+  /**
+   * The root identifier of the RO Crate
+   */
+  readonly rootId: string;
+
+  /**
+   * Generate a local flat lookup table for context terms
+   */
+  resolveContext(): Promise<void>;
+
+  /**
+   * Get the context term definition. This method will also search for term defined locally in the graph.
+   * Make sure `resolveContext()` has been called prior calling this method.
+   */
+  getDefinition(term: string): RawEntity | undefined;
+
+  /**
+   * Get the context term name from it's definition id.
+   * Make sure `resolveContext()` has been called prior calling this method.
+   * @param {string|object} definition
+   */
+  getTerm(definition: string | Record<string, unknown>): string | undefined;
+
+  /**
+   * Get an entity from the graph.
+   * If config.link is true, any reference (object with just "@id" property)
+   * is resolved as a nested object.
+   * @param id An entity identifier
+   * @return A wrapper for entity that resolves properties as linked objects
+   */
+  getEntity(id: string): Entity | undefined;
+
+  /**
+   * Check if entity exists in the graph
+   * @param id An entity identifier
+   */
+  hasEntity(id: string): boolean;
+
+  /**
+   * Get named identifier
+   */
+  getIdentifier(name: string): string | undefined;
+
+  /**
+   * Convert the rocrate into plain JSON object.
+   * The value returned by this method is used when JSON.stringify() is used on the ROCrate object.
+   * @return plain JSON object
+   */
+  toJSON(): Record<string, unknown>;
+}
+
+export interface ROCrateConfig {
+  /** Always return property of an Entity as an array (eg when using getEntity() method) */
+  array?: boolean;
+
+  /** Resolve linked node as nested object */
+  link?: boolean;
+
+  /** When importing from json, a subsequent duplicate entity always replaces the existing one */
+  replace?: boolean;
+
+  /** When replacing or updating an entity, merge the values and the properties instead of full replace */
+  merge?: boolean;
+
+  /** Allow duplicate values in a property that has multiple values */
+  duplicate?: boolean;
+
+  /** The default value for `@type` to be used when adding a new entity and the property is not specified. Default to 'Thing' */
+  defaultType?: string;
+}
+
+interface ValidationEntry {
+  id: string;
+  status: "success" | "warning" | "error";
+  message: string;
+  clause: string;
+}
+
+export type ValidationResults = ValidationEntry[];
+
+export interface RawEntity {
+  readonly "@id": string;
+  readonly [key: string]: unknown;
+}
+
+interface NodeRef {
+  readonly "@id": string;
+  readonly "@reverse": Record<string, unknown>;
+}
+
+export interface Entity extends RawEntity, NodeRef {
+  toJSON(): RawEntity;
+}

--- a/src/types/ro-crate.d.ts
+++ b/src/types/ro-crate.d.ts
@@ -1,116 +1,33 @@
 declare module "ro-crate" {
-  export { ROCrate, validate };
+  type IROCrate = import("./ro-crate-interfaces").ROCrateReadOnlyView;
+  type RawEntity = import("./ro-crate-interfaces").RawEntity;
+  type Entity = import("./ro-crate-interfaces").Entity;
 
   /**
    * Class for building, navigating, testing and rendering ROCrates
    */
-  declare class ROCrate {
+  export class ROCrate implements IROCrate {
     constructor(json: Record<string, unknown>, config?: ROCrateConfig);
 
-    /**
-     * The context part of the crate. An alias for '@context'.
-     * This returns the original context information.
-     */
+    // TODO: This is a read-only view of the ROCrate object limited to the scope of the current project.
+    // These type definitions should be completed and moved to a new package @types/ro-crate and
+    // contributed to DefinitelyTyped (https://github.com/DefinitelyTyped/DefinitelyTyped)
+
     context: unknown[];
-
-    /**
-     * An array of all nodes in the graph. An alias for '@graph'
-     */
-    graph: unknown[];
-
+    graph: Entity[];
     graphSize: number;
     metadataFileEntity: Entity;
     rootDataset: Entity;
-
-    /**
-     * The root identifier of the RO Crate
-     */
     rootId: string;
 
-    /**
-     * Generate a local flat lookup table for context terms
-     */
-    async resolveContext();
-
-    /**
-     * Get the context term definition. This method will also search for term defined locally in the graph.
-     * Make sure `resolveContext()` has been called prior calling this method.
-     */
+    resolveContext(): Promise<void>;
     getDefinition(term: string): RawEntity | undefined;
-
-    /**
-     * Get an entity from the graph.
-     * If config.link is true, any reference (object with just "@id" property)
-     * is resolved as a nested object.
-     * @param id An entity identifier
-     * @return A wrapper for entity that resolves properties as linked objects
-     */
+    getTerm(definition: string | Record<string, unknown>): string | undefined;
     getEntity(id: string): Entity | undefined;
-
-    /**
-     * Check if entity exists in the graph
-     * @param id An entity identifier
-     */
-    hasEntity(id): boolean;
-
-    /**
-     * Get named identifier
-     */
+    hasEntity(id: string): boolean;
     getIdentifier(name: string): string | undefined;
-
-    /**
-     * Convert the rocrate into plain JSON object.
-     * The value returned by this method is used when JSON.stringify() is used on the ROCrate object.
-     * @return plain JSON object
-     */
-    toJSON();
+    toJSON(): Record<string, unknown>;
   }
 
-  declare function validate(crate: ROCrate, files: unknown): Promise<ValidationResults>;
-
-  interface ROCrateConfig {
-    /** Always return property of an Entity as an array (eg when using getEntity() method) */
-    array?: boolean;
-
-    /** Resolve linked node as nested object */
-    link?: boolean;
-
-    /** When importing from json, a subsequent duplicate entity always replaces the existing one */
-    replace?: boolean;
-
-    /** When replacing or updating an entity, merge the values and the properties instead of full replace */
-    merge?: boolean;
-
-    /** Allow duplicate values in a property that has multiple values */
-    duplicate?: boolean;
-
-    /** The default value for `@type` to be used when adding a new entity and the property is not specified. Default to 'Thing' */
-    defaultType?: string;
-  }
-
-  interface ValidationEntry {
-    id: string;
-    status: "success" | "warning" | "error";
-    message: string;
-    clause: string;
-  }
-
-  type ValidationResults = ValidationEntry[];
-
-  interface Entity {
-    "@id": string;
-    "@reverse": Record<string, unknown>;
-    toJSON(): RawEntity;
-    [key: string]: unknown;
-  }
-
-  interface RawEntity {
-    "@id": string;
-    [key: string]: unknown;
-  }
-
-  interface NodeRef {
-    "@id": string;
-    "@reverse": Record<string, unknown>;
-  }
+  export function validate(crate: ROCrate, files: unknown): Promise<ValidationResults>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1075,11 +1075,11 @@ core-util-is@~1.0.0:
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 cross-fetch@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-4.0.0.tgz#f037aef1580bb3a1a35164ea2a848ba81b445983"
-  integrity sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-4.1.0.tgz#8f69355007ee182e47fa692ecbaa37a52e43c3d2"
+  integrity sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==
   dependencies:
-    node-fetch "^2.6.12"
+    node-fetch "^2.7.0"
 
 cross-spawn@^7.0.0:
   version "7.0.5"
@@ -1896,7 +1896,7 @@ node-emoji@^2.1.3:
     emojilib "^2.4.0"
     skin-tone "^2.0.0"
 
-node-fetch@^2.6.12:
+node-fetch@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
@@ -2159,10 +2159,10 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-ro-crate@^3.4.1:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/ro-crate/-/ro-crate-3.4.1.tgz#73ff1ac93934f1c6e430e0ee76d44d09e1cfbcee"
-  integrity sha512-OnHmSTw1OV9ukngOxVnAQUTj0GK9+b4MCroMy38oKHLE2U81vCPnkwyrGw8HLendL0xnIOoTIai+lUxCKudyTQ==
+ro-crate@^3.4.6:
+  version "3.4.6"
+  resolved "https://registry.yarnpkg.com/ro-crate/-/ro-crate-3.4.6.tgz#8854674298e14e6fe33d681337274b93b383861e"
+  integrity sha512-+TSJOblZRz+GXq86dF8EFIRCOVJaicelom+S7POIlniGy2/Jl7wO62BvcL7KuksR7PHpIgSJ5qBZr2qCeQ0iyg==
   dependencies:
     commander "^12.0.0"
     cross-fetch "^4.0.0"


### PR DESCRIPTION
Just refactoring some of the type definitions so they are exposed to the library consumers. Before this change, only the library itself was able to see the types properly.