### PR TITLE
Refactor explorer API

### DIFF
--- a/.changeset/famous-cycles-cross.md
+++ b/.changeset/famous-cycles-cross.md
@@ -1,0 +1,14 @@
+---
+"ro-crate-zip-explorer": minor
+---
+
+Refactor explorer class API
+
+This refactors the `ZipExplorer` and `ROCrateZipExplorer` classes, as well as the related interfaces. These changes include **breaking changes** to the API, but please note that **the API is not yet stable** and will likely change further in the future until a stable release is reached.
+
+The main changes are:
+
+- A new `ZipExplorer` class has been introduced, which is a generic class that can be used to explore any ZIP archive.
+- **(Breaking change)** The `ROCrateZip` interface has been removed.
+- **(Breaking change)** Calling the `open` method on a `ZipExplorer` or `ROCrateZipExplorer` instance now returns a `Promise` that resolves to a `ZipArchive` object.
+- **(Breaking change)** When using `ROCrateZipExplorer`, the `hasCrate` and `crate` properties can be used to check if the ZIP archive contains a RO-Crate and to access the RO-Crate metadata, respectively.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # RO-Crate Zip Explorer
 
-**RO-Crate Zip Explorer** is a TypeScript library that provides an API for browsing and reading **RO-Crate metadata files** directly within ZIP archives. It enables web developers to integrate RO-Crate import functionality into their projects, supporting both **local and remote ZIP archives**.
+**RO-Crate Zip Explorer** is a TypeScript library for browsing and extracting **RO-Crate metadata files** directly within ZIP archives. It provides a read-only interface to access and navigate **RO-Crate metadata** while leveraging the [ro-crate-js](https://github.com/Language-Research-Technology/ro-crate-js/tree/master) library.
 
 ## ✨ Features
 
-- Open and read ZIP archives containing **RO-Crate metadata**.
-- Extract and parse **RO-Crate metadata files**.
-- Access individual **files and directories** within the ZIP archive.
-- Support for **both local and remote ZIP archives**.
+- **Supports both local and remote ZIP archives**.
+- **Browse ZIP archives** contents with ease without downloading the entire archive.
+- **Extract and parse RO-Crate metadata** effortlessly.
+- **Fetch and read files** from the ZIP archive.
+- **Compatible with modern browsers** and **Node.js** environments.
+- **Fully typed with TypeScript**.
 
 ## 📦 Installation
 
@@ -21,13 +23,19 @@ yarn add ro-crate-zip-explorer
 
 ## 🚀 Usage
 
+### Supported Environments
+
+- **Browser**: Works with `<input type="file">` for local file selection.
+- **Node.js**: Supports loading ZIP archives from the filesystem.
+- **Remote Files**: Can fetch and parse ZIP files over HTTP(S), provided proper CORS headers are configured.
+
 ### Importing the Library
 
 ```typescript
 import { ROCrateZipExplorer } from "ro-crate-zip-explorer";
 ```
 
-### Opening a Local ZIP Archive
+### Opening a Local RO-Crate ZIP Archive
 
 ```typescript
 const fileInput = document.querySelector('input[type="file"]');
@@ -35,25 +43,37 @@ const fileInput = document.querySelector('input[type="file"]');
 fileInput.addEventListener("change", async (event) => {
   const file = event.target.files[0];
   const explorer = new ROCrateZipExplorer(file);
-  const { crate, zip } = await explorer.open();
+  const zip = await explorer.open();
 
-  console.log(crate.context);
-  console.log(zip.size);
+  console.log("Total files and directories in the ZIP:", zip.entries.length);
+  console.log("RO-Crate Root Dataset:", explorer.crate.rootDataset);
 });
 ```
 
-### Opening a Remote ZIP Archive
+### Opening a Remote RO-Crate ZIP Archive
 
 ```typescript
 const explorer = new ROCrateZipExplorer("https://example.com/archive.zip");
-const { crate, zip } = await explorer.open();
+const zip = await explorer.open();
 
-console.log(crate.context);
-console.log(zip.size);
+console.log("Total files and directories in the ZIP:", zip.entries.length);
+console.log("RO-Crate Root Dataset:", explorer.crate.rootDataset);
 ```
 
+> [!TIP]
+> Need to explore a standard ZIP file? Use the `ZipExplorer` class instead:
+>
+> ```typescript
+> import { ZipExplorer } from "ro-crate-zip-explorer";
+>
+> const explorer = new ZipExplorer("https://example.com/archive.zip");
+> const zip = await explorer.open();
+>
+> console.log("Total files and directories in the ZIP:", zip.entries.length);
+> ```
+
 > [!IMPORTANT]
-> This library uses the **Fetch API** to explore remote ZIP archives. Ensure proper **CORS headers** are set if the archive is hosted on a different domain.
+> This library uses the **Fetch API** to load remote ZIP archives. Ensure the server provides proper **CORS headers** if hosting files on another domain.
 
 ### Extracting File Contents
 
@@ -63,25 +83,44 @@ const fileEntry = zip.findFileByName("path/to/file.txt");
 if (fileEntry) {
   const fileContents = await explorer.getFileContents(fileEntry);
   console.log(new TextDecoder().decode(fileContents));
+} else {
+  console.error("File not found in the ZIP archive.");
 }
 ```
 
 ## 🛠 Example Projects
 
-Explore how **RO-Crate Zip Explorer** can be used in real-world applications!
+Explore how **RO-Crate Zip Explorer** integrates into other projects:
 
 ### 📌 Vue.js Example
 
-A Vue.js example demonstrating how to integrate **RO-Crate Zip Explorer** into a frontend project is available in the repository:
+A simple **Vue.js** demo is available in the repository:
 
 🔗 **[Vue Example: RO-Crate-Zip-Vue](https://github.com/davelopez/ro-crate-zip-explorer/tree/main/examples/vue/ro-crate-zip-vue#ro-crate-zip-vue)**
 
-This example showcases:
+#### Example Usage in Vue:
 
-- Opening a local or remote RO-Crate ZIP archive
-- Handling file contents from the archive
+```vue
+<template>
+  <input type="file" @change="handleFileUpload" />
+</template>
 
-Clone the repository and try it out!
+<script setup>
+import { ROCrateZipExplorer } from "ro-crate-zip-explorer";
+
+const handleFileUpload = async (event) => {
+  try {
+    const file = event.target.files[0];
+    const explorer = new ROCrateZipExplorer(file);
+    const zip = await explorer.open();
+
+    console.log("Total files and directories in the ZIP:", zip.entries.length);
+  } catch (error) {
+    console.error("Error opening ZIP archive:", error);
+  }
+};
+</script>
+```
 
 ## 📄 License
 

--- a/examples/vue/ro-crate-zip-vue/src/components/BrowseLocal.vue
+++ b/examples/vue/ro-crate-zip-vue/src/components/BrowseLocal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, reactive, computed, watch } from "vue";
 import { useFileSystemAccess } from "@vueuse/core";
-import { ROCrateZipExplorer, type ROCrateZip } from "ro-crate-zip-explorer";
+import { ROCrateZipExplorer, type ZipArchive } from "ro-crate-zip-explorer";
 import Explorer from "./Explorer.vue";
 
 const dataType = ref<"Text" | "ArrayBuffer" | "Blob">("ArrayBuffer");
@@ -29,12 +29,12 @@ const results = reactive({
   file: fileSystemAccess.file,
 });
 
-const roCrateZipFile = ref<ROCrateZip>();
+const localZipArchive = ref<ZipArchive>();
 
 watch(results, async () => {
   if (results.file) {
     const explorer = new ROCrateZipExplorer(results.file);
-    roCrateZipFile.value = await explorer.open();
+    localZipArchive.value = await explorer.open();
   }
 });
 </script>
@@ -78,7 +78,7 @@ watch(results, async () => {
         <span class="green">Last modified:</span> {{ new Date(results.fileLastModified) }}
       </p>
 
-      <Explorer :ro-crate-zip-file="roCrateZipFile" />
+      <Explorer :zip-archive="localZipArchive" />
     </div>
   </main>
 </template>

--- a/examples/vue/ro-crate-zip-vue/src/components/BrowseRemote.vue
+++ b/examples/vue/ro-crate-zip-vue/src/components/BrowseRemote.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
-import { ROCrateZipExplorer, type ROCrateZip } from "ro-crate-zip-explorer";
+import { ROCrateZipExplorer, type ZipArchive } from "ro-crate-zip-explorer";
 import Explorer from "./Explorer.vue";
 
 const url = ref<string>(
   "https://raw.githubusercontent.com/davelopez/ro-crate-zip-explorer/refs/heads/main/tests/test-data/rocrate-test.zip",
 );
-const roCrateZipFile = ref<ROCrateZip>();
+const remoteZipArchive = ref<ZipArchive>();
 
 const canExploreRemote = computed(() => {
   try {
@@ -28,7 +28,7 @@ const exploreTooltip = computed(() => {
 async function exploreRemote() {
   console.log("URL", url.value);
   const explorer = new ROCrateZipExplorer(url.value);
-  roCrateZipFile.value = await explorer.open();
+  remoteZipArchive.value = await explorer.open();
 }
 </script>
 
@@ -49,7 +49,7 @@ async function exploreRemote() {
 
     <button :disabled="!canExploreRemote" @click="exploreRemote" class="button" :title="exploreTooltip">Explore</button>
 
-    <Explorer :ro-crate-zip-file="roCrateZipFile" />
+    <Explorer :zip-archive="remoteZipArchive" />
   </main>
 </template>
 

--- a/examples/vue/ro-crate-zip-vue/src/components/Explorer.vue
+++ b/examples/vue/ro-crate-zip-vue/src/components/Explorer.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import type { ROCrateZip, ZipFileEntry } from "ro-crate-zip-explorer";
+import type { ZipArchive, ZipFileEntry } from "ro-crate-zip-explorer";
 
 interface Props {
-  roCrateZipFile?: ROCrateZip;
+  zipArchive?: ZipArchive;
 }
 
 const props = defineProps<Props>();
@@ -20,10 +20,10 @@ async function downloadFile(entry: ZipFileEntry) {
 </script>
 
 <template>
-  <div v-if="roCrateZipFile">
+  <div v-if="zipArchive">
     <h3>RO-Crate Zip file contents</h3>
     <ul>
-      <li v-for="file in roCrateZipFile.zip.entries" :key="file.path">
+      <li v-for="file in zipArchive.entries" :key="file.path">
         <span v-if="file.type == 'File'"> 📄 </span>
         <span v-else-if="file.type == 'Directory'"> 📁 </span>
         {{ file.path }}

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -1,5 +1,6 @@
 import { ROCrate } from "ro-crate";
-import type { ZipArchive, ZipFileEntry, ZipService } from "./interfaces.js";
+import type { IROCrateExplorer, IZipExplorer, ZipArchive, ZipFileEntry, ZipService } from "./interfaces.js";
+import type { ROCrateReadOnlyView } from "./types/ro-crate-interfaces.js";
 import { LocalZipService } from "./zip/localZipService.js";
 import { RemoteZipService } from "./zip/remoteZipService.js";
 
@@ -17,6 +18,7 @@ const ROCRATE_METADATA_FILENAME = "ro-crate-metadata.json";
  * console.log(zip.size);
  * ```
  */
+export class ZipExplorer implements IZipExplorer {
   protected readonly zipService: ZipService;
   protected zipArchive?: ZipArchive;
 
@@ -54,7 +56,7 @@ const ROCRATE_METADATA_FILENAME = "ro-crate-metadata.json";
  * }
  * ```
  */
-export class ROCrateZipExplorer extends ZipExplorer {
+export class ROCrateZipExplorer extends ZipExplorer implements IROCrateExplorer {
   private _crate?: ROCrate | null = undefined;
 
   public get hasCrate(): boolean {
@@ -62,9 +64,10 @@ export class ROCrateZipExplorer extends ZipExplorer {
     return Boolean(this._crate);
   }
 
-  public get crate(): ROCrate {
+  public get crate(): ROCrateReadOnlyView {
     if (this._crate) {
-      return this._crate;
+      // Here only an immutable view of the RO-Crate is returned
+      return this._crate as ROCrateReadOnlyView;
     }
     this.ensureZipArchiveOpen();
     throw new Error("No RO-Crate metadata found in the ZIP archive");

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -5,7 +5,18 @@ import { RemoteZipService } from "./zip/remoteZipService.js";
 
 const ROCRATE_METADATA_FILENAME = "ro-crate-metadata.json";
 
-export class ZipExplorer {
+/**
+ * A class for exploring the contents of a ZIP archive.
+ *
+ * You can either pass a File object representing a ZIP archive or a URL string pointing to a remotely hosted ZIP archive.
+ *
+ * Example usage:
+ * ```typescript
+ * const explorer = new ZipExplorer("https://example.com/archive.zip");
+ * const zip = await explorer.open();
+ * console.log(zip.size);
+ * ```
+ */
   protected readonly zipService: ZipService;
   protected zipArchive?: ZipArchive;
 
@@ -33,9 +44,14 @@ export class ZipExplorer {
  * Example usage:
  * ```typescript
  * const explorer = new ROCrateZipExplorer("https://example.com/archive.zip");
- * const { crate, zip } = await explorer.open();
- * console.log(crate.context);
+ * const zip = await explorer.open();
  * console.log(zip.size);
+ *
+ * if (explorer.hasCrate) {
+ *   console.log(explorer.crate.graphSize);
+ * } else {
+ *   console.log("No RO-Crate metadata found in the ZIP archive");
+ * }
  * ```
  */
 export class ROCrateZipExplorer extends ZipExplorer {

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -1,6 +1,6 @@
 import { ROCrate } from "ro-crate";
 import type { IROCrateExplorer, IZipExplorer, ZipArchive, ZipFileEntry, ZipService } from "./interfaces.js";
-import type { ROCrateReadOnlyView } from "./types/ro-crate-interfaces.js";
+import type { ROCrateImmutableView } from "./types/ro-crate-interfaces.js";
 import { LocalZipService } from "./zip/localZipService.js";
 import { RemoteZipService } from "./zip/remoteZipService.js";
 
@@ -64,10 +64,10 @@ export class ROCrateZipExplorer extends ZipExplorer implements IROCrateExplorer 
     return Boolean(this._crate);
   }
 
-  public get crate(): ROCrateReadOnlyView {
+  public get crate(): ROCrateImmutableView {
     if (this._crate) {
       // Here only an immutable view of the RO-Crate is returned
-      return this._crate as ROCrateReadOnlyView;
+      return this._crate as ROCrateImmutableView;
     }
     this.ensureZipArchiveOpen();
     throw new Error("No RO-Crate metadata found in the ZIP archive");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { ROCrateZipExplorer, ZipExplorer } from "./explorer.js";
 export type { AnyZipEntry, ZipDirectoryEntry, ZipFileEntry } from "./interfaces.js";
-export type { Entity as ROCrateEntity, ROCrateReadOnlyView } from "./types/ro-crate-interfaces.js";
+export type { Entity as ROCrateEntity, ROCrateImmutableView } from "./types/ro-crate-interfaces.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { ROCrateZipExplorer, ZipExplorer } from "./explorer.js";
-export type { AnyZipEntry, ZipDirectoryEntry, ZipFileEntry } from "./interfaces.js";
+export type { AnyZipEntry, ZipArchive, ZipDirectoryEntry, ZipFileEntry } from "./interfaces.js";
 export type { Entity as ROCrateEntity, ROCrateImmutableView } from "./types/ro-crate-interfaces.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { ROCrateZipExplorer, type ROCrateZip } from "./explorer.js";
+export { ROCrateZipExplorer, ZipExplorer } from "./explorer.js";
 export type { AnyZipEntry, ZipDirectoryEntry, ZipFileEntry } from "./interfaces.js";
 export type { Entity as ROCrateEntity, ROCrateReadOnlyView } from "./types/ro-crate-interfaces.js";

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -20,16 +20,35 @@ export interface ZipArchive {
   findFileByName(fileName: string): ZipFileEntry | undefined;
 }
 
+/**
+ * Represents either a file or a directory in a ZIP archive.
+ */
+export type AnyZipEntry = ZipFileEntry | ZipDirectoryEntry;
+
+/**
+ * Represents a file in a ZIP archive.
+ */
 export interface ZipFileEntry extends ZipEntry {
   readonly type: "File";
+
+  /**
+   * Extracts the file content from the ZIP archive.
+   * @returns A promise that resolves with the file content as a Uint8Array.
+   * @throws Throws an error if the service is not initialized (i.e., if `open` has not been called)
+   * or if the file cannot be extracted.
+   *
+   * @remarks
+   * This loads the entire file into memory. Consider using this method only for small files.
+   */
   data(): Promise<Uint8Array>;
 }
 
+/**
+ * Represents a directory in a ZIP archive.
+ */
 export interface ZipDirectoryEntry extends ZipEntry {
   readonly type: "Directory";
 }
-
-export type AnyZipEntry = ZipFileEntry | ZipDirectoryEntry;
 
 /**
  * Represents a service for working with ZIP archives.

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,16 +1,3 @@
-import type { ROCrateReadOnlyView } from "./types/ro-crate-interfaces.js";
-
-/**
- * Represents a Zip archive containing an RO-Crate manifest.
- */
-export interface ROCrateZip {
-  /** The RO-Crate metadata object. */
-  readonly crate: ROCrateReadOnlyView;
-
-  /** The ZIP archive and its contents. */
-  readonly zip: ZipArchive;
-}
-
 /**
  * Represents a ZIP archive and its contents.
  */

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-import type { ROCrateReadOnlyView } from "./types/ro-crate-interfaces.js";
+import type { ROCrateImmutableView } from "./types/ro-crate-interfaces.js";
 
 /**
  * Represents an interface for a service that can open a ZIP archive,
@@ -34,7 +34,7 @@ export interface IROCrateExplorer extends IZipExplorer {
    * The RO-Crate metadata in the ZIP archive.
    * @throws Throws an error if the ZIP archive does not contain an RO-Crate manifest.
    */
-  crate: ROCrateReadOnlyView;
+  crate: ROCrateImmutableView;
 }
 
 /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,3 +1,42 @@
+import type { ROCrateReadOnlyView } from "./types/ro-crate-interfaces.js";
+
+/**
+ * Represents an interface for a service that can open a ZIP archive,
+ * explore its contents, and extract files from it.
+ */
+export interface IZipExplorer {
+  /**
+   * Opens the ZIP archive and performs any necessary initialization.
+   * @returns A promise that resolves when the ZIP archive is opened.
+   * @throws Throws an error if the ZIP archive cannot be opened.
+   */
+  open(): Promise<ZipArchive>;
+
+  /**
+   * Extracts the contents of a file from the ZIP archive.
+   * @param fileEntry - The file information object.
+   * @returns A promise that resolves with the file content as a Uint8Array.
+   * @throws Throws an error if the file cannot be extracted.
+   *
+   * @remarks
+   * This loads the entire file into memory. Consider using this method only for small files.
+   */
+  getFileContents(fileEntry: ZipFileEntry): Promise<Uint8Array>;
+}
+
+export interface IROCrateExplorer extends IZipExplorer {
+  /**
+   * Determines if the ZIP archive contains an RO-Crate manifest.
+   */
+  hasCrate: boolean;
+
+  /**
+   * The RO-Crate metadata in the ZIP archive.
+   * @throws Throws an error if the ZIP archive does not contain an RO-Crate manifest.
+   */
+  crate: ROCrateReadOnlyView;
+}
+
 /**
  * Represents a ZIP archive and its contents.
  */

--- a/src/types/ro-crate-interfaces.ts
+++ b/src/types/ro-crate-interfaces.ts
@@ -5,7 +5,7 @@
  * It also provides methods for resolving context terms, getting entity definitions,
  * getting entities from the graph, and checking if an entity exists in the graph.
  */
-export interface ROCrateReadOnlyView {
+export interface ROCrateImmutableView {
   /**
    * The context part of the crate. An alias for '@context'.
    * This returns the original context information.
@@ -36,7 +36,7 @@ export interface ROCrateReadOnlyView {
   /**
    * The root identifier of the RO Crate
    */
-  readonly rootId: string;
+  get rootId(): string;
 
   /**
    * Generate a local flat lookup table for context terms

--- a/src/types/ro-crate.d.ts
+++ b/src/types/ro-crate.d.ts
@@ -1,5 +1,5 @@
 declare module "ro-crate" {
-  type IROCrate = import("./ro-crate-interfaces").ROCrateReadOnlyView;
+  type ROCrateImmutableView = import("./ro-crate-interfaces").ROCrateImmutableView;
   type RawEntity = import("./ro-crate-interfaces").RawEntity;
   type Entity = import("./ro-crate-interfaces").Entity;
 
@@ -9,16 +9,12 @@ declare module "ro-crate" {
   export class ROCrate implements IROCrate {
     constructor(json: Record<string, unknown>, config?: ROCrateConfig);
 
-    // TODO: This is a read-only view of the ROCrate object limited to the scope of the current project.
-    // These type definitions should be completed and moved to a new package @types/ro-crate and
-    // contributed to DefinitelyTyped (https://github.com/DefinitelyTyped/DefinitelyTyped)
-
     context: unknown[];
     graph: Entity[];
     graphSize: number;
     metadataFileEntity: Entity;
     rootDataset: Entity;
-    rootId: string;
+    get rootId(): string;
 
     resolveContext(): Promise<void>;
     getDefinition(term: string): RawEntity | undefined;
@@ -30,4 +26,18 @@ declare module "ro-crate" {
   }
 
   export function validate(crate: ROCrate, files: unknown): Promise<ValidationResults>;
+
+  /**
+   * Interface for a ROCrate object exposing all its methods.
+   */
+  interface IROCrate extends ROCrateImmutableView {
+    // Note: The scope of the current project does not require the full type definitions of the
+    // IROCrate interface.
+
+    // TODO: These type definitions should be completed and moved to a new package @types/ro-crate and
+    // contributed to DefinitelyTyped (https://github.com/DefinitelyTyped/DefinitelyTyped) by
+    // the RO-Crate community.
+
+    set rootId(newId: string);
+  }
 }

--- a/src/zip/zipService.ts
+++ b/src/zip/zipService.ts
@@ -152,7 +152,7 @@ export abstract class AbstractZipService implements ZipService {
     const fileNameEndOffset = fileNameStartOffset + fileNameLength;
     const fileNameBuffer = dataView.buffer.slice(fileNameStartOffset, fileNameEndOffset);
 
-    const fileName = new TextDecoder().decode(fileNameBuffer);
+    const fileName = new TextDecoder().decode(new Uint8Array(fileNameBuffer));
     const dateTime = dataView.getUint32(offset + 12, true);
     const crc32 = dataView.getUint32(offset + 16, true);
     const compressionMethod = dataView.getUint16(offset + 10, true);


### PR DESCRIPTION
This refactors the `ZipExplorer` and `ROCrateZipExplorer` classes, as well as the related interfaces. These changes include **breaking changes** to the API, but please note that **the API is not yet stable** and will likely change further in the future until a stable release is reached.

The main changes are:

- A new `ZipExplorer` class has been introduced, which is a generic class that can be used to explore any ZIP archive.
- **(Breaking change)** The `ROCrateZip` interface has been removed.
- **(Breaking change)** Calling the `open` method on a `ZipExplorer` or `ROCrateZipExplorer` instance now returns a `Promise` that resolves to a `ZipArchive` object.
- **(Breaking change)** When using `ROCrateZipExplorer`, the `hasCrate` and `crate` properties can be used to check if the ZIP archive contains a RO-Crate and to access the RO-Crate metadata, respectively.