### PR TITLE
Use map for zip entries

### DIFF
--- a/.changeset/solid-areas-look.md
+++ b/.changeset/solid-areas-look.md
@@ -1,0 +1,5 @@
+---
+"ro-crate-zip-explorer": patch
+---
+
+Use map for entries

--- a/examples/vue/ro-crate-zip-vue/src/components/Explorer.vue
+++ b/examples/vue/ro-crate-zip-vue/src/components/Explorer.vue
@@ -23,7 +23,7 @@ async function downloadFile(entry: ZipFileEntry) {
   <div v-if="zipArchive">
     <h3>RO-Crate Zip file contents</h3>
     <ul>
-      <li v-for="file in zipArchive.entries" :key="file.path">
+      <li v-for="file in zipArchive.entries.values()" :key="file.path">
         <span v-if="file.type == 'File'"> 📄 </span>
         <span v-else-if="file.type == 'Directory'"> 📁 </span>
         {{ file.path }}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -49,6 +49,9 @@ export interface ZipArchive {
   /** The list of files and directories in the ZIP archive. */
   readonly entries: AnyZipEntry[];
 
+  /** A map of file names to their corresponding file information objects. */
+  readonly entryMap: Map<string, AnyZipEntry>;
+
   /** The total size of the ZIP archive in bytes. */
   readonly size: number;
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -10,6 +10,9 @@ export type ZipSource = File | string;
  * explore its contents, and extract files from it.
  */
 export interface IZipExplorer {
+  /** A map of file names to their corresponding file information objects. */
+  readonly entries: Map<string, AnyZipEntry>;
+
   /**
    * Opens the ZIP archive and performs any necessary initialization.
    * @returns A promise that resolves when the ZIP archive is opened.
@@ -46,11 +49,8 @@ export interface IROCrateExplorer extends IZipExplorer {
  * Represents a ZIP archive and its contents.
  */
 export interface ZipArchive {
-  /** The list of files and directories in the ZIP archive. */
-  readonly entries: AnyZipEntry[];
-
   /** A map of file names to their corresponding file information objects. */
-  readonly entryMap: Map<string, AnyZipEntry>;
+  readonly entries: Map<string, AnyZipEntry>;
 
   /** The total size of the ZIP archive in bytes. */
   readonly size: number;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -71,6 +71,14 @@ export interface ZipArchive {
    * @throws Throws an error if the service is not initialized (i.e., if `open` has not been called).
    */
   findFileByName(fileName: string): ZipFileEntry | undefined;
+
+  /**
+   * Finds an entry in the ZIP archive that matches a specific criteria.
+   * @param predicate - A function that takes a file information object and returns a boolean indicating whether the file matches the criteria.
+   * @returns The first file information object that matches the criteria or `undefined` if no match is found.
+   * @throws Throws an error if the service is not initialized (i.e., if `open` has not been called).
+   */
+  findEntry(predicate: (entry: AnyZipEntry) => boolean): AnyZipEntry | undefined;
 }
 
 /**

--- a/src/zip/zipService.ts
+++ b/src/zip/zipService.ts
@@ -31,6 +31,7 @@ export abstract class AbstractZipService implements ZipService {
     const entries = await this.getZipEntries();
     const zipArchive: ZipArchive = {
       entries,
+      entryMap: new Map(entries.map((entry) => [entry.path, entry])),
       size: this.zipSize,
       source: this.source,
       isZip64: this.eocdData.isZip64,

--- a/src/zip/zipService.ts
+++ b/src/zip/zipService.ts
@@ -44,6 +44,14 @@ export abstract class AbstractZipService implements ZipService {
         }
         return foundFileEntry;
       },
+      findEntry: (predicate: (entry: AnyZipEntry) => boolean) => {
+        for (const entry of entries.values()) {
+          if (predicate(entry)) {
+            return entry;
+          }
+        }
+        return undefined;
+      },
     };
     this.cleanupAfterInitialization();
     return zipArchive;

--- a/src/zip/zipService.ts
+++ b/src/zip/zipService.ts
@@ -31,12 +31,19 @@ export abstract class AbstractZipService implements ZipService {
     const entries = await this.getZipEntries();
     const zipArchive: ZipArchive = {
       entries,
-      entryMap: new Map(entries.map((entry) => [entry.path, entry])),
       size: this.zipSize,
       source: this.source,
       isZip64: this.eocdData.isZip64,
-      findFileByName: (fileName: string) =>
-        entries.find((file) => file.type === "File" && file.path.endsWith(fileName)) as ZipFileEntry,
+      findFileByName: (fileName: string) => {
+        let foundFileEntry: ZipFileEntry | undefined;
+        for (const entry of entries.values()) {
+          if (entry.type === "File" && entry.path.endsWith(fileName)) {
+            foundFileEntry = entry;
+            break;
+          }
+        }
+        return foundFileEntry;
+      },
     };
     this.cleanupAfterInitialization();
     return zipArchive;
@@ -99,19 +106,19 @@ export abstract class AbstractZipService implements ZipService {
 
   /**
    * Retrieves the ZIP entries from the Central Directory.
-   * @returns A promise that resolves with an array of ZIP file entries.
+   * @returns A promise that resolves with a map of ZIP file entries (by path).
    * @throws An error if the ZIP entries cannot be parsed.
    */
-  protected async getZipEntries(): Promise<AnyZipEntry[]> {
+  protected async getZipEntries(): Promise<Map<string, AnyZipEntry>> {
     try {
-      const entries = [];
+      const entries = new Map<string, AnyZipEntry>();
       let offset = 0;
       const centralDirectoryData = await this.getCentralDirectory();
       while (offset < centralDirectoryData.byteLength) {
         const centralDirectoryFileHeader = this.parseCentralDirectoryFileHeader(centralDirectoryData, offset);
         const entry = this.createZipEntry(centralDirectoryFileHeader);
 
-        entries.push(entry);
+        entries.set(entry.path, entry);
         offset += centralDirectoryFileHeader.nextOffset;
       }
       return entries;

--- a/tests/explorer.test.ts
+++ b/tests/explorer.test.ts
@@ -21,8 +21,12 @@ describe("ROCrateZipExplorer", () => {
     const explorer = new ROCrateZipExplorer(nonROCrateTestFile.source);
 
     describe("Before opening", () => {
+      it("should throw an error when trying to access the entries", () => {
+        expect(() => explorer.entries).toThrow("Please call open() before accessing the ZIP archive");
+      });
+
       it("should throw an error when trying to check the RO-Crate presence", () => {
-        expect(() => explorer.hasCrate).toThrow("Please call open() before trying to access the RO-Crate");
+        expect(() => explorer.hasCrate).toThrow("Please call open() before accessing the ZIP archive");
       });
     });
 
@@ -62,13 +66,17 @@ const testExplorer = (zipTestFile: TestZipFile) => {
       expect(zipArchive).toBeDefined();
     });
 
+    it("should have the correct number of entries in the ZIP archive", () => {
+      expect(zipArchive.entries.size).toBe(zipTestFile.expectations.entriesCount);
+    });
+
     it("should indicate that the ZIP archive contains an RO-Crate", () => {
       expect(explorer.hasCrate).toBe(true);
     });
 
     it("should provide the RO-Crate metadata", () => {
       expect(explorer.crate).toBeDefined();
-      verifyCrateMetadataContext(explorer.crate as Record<string, unknown>);
+      verifyCrateMetadataContext(explorer.crate);
     });
 
     it("should return the same ZIP archive when called again", async () => {

--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -2,6 +2,7 @@ import fs from "fs";
 import path from "path";
 import util from "util";
 import { expect } from "vitest";
+import type { ROCrateImmutableView } from "../src/index.js";
 import type { ZipService } from "../src/interfaces.js";
 import { LocalZipService } from "../src/zip/localZipService.js";
 import { RemoteZipService } from "../src/zip/remoteZipService.js";
@@ -102,7 +103,7 @@ export interface TestZipFile {
 }
 
 export function verifyCrateMetadataContext(
-  crate: Record<string, unknown>,
+  crate: ROCrateImmutableView | Record<string, unknown>,
   expectedContextUrl = "https://w3id.org/ro/crate/1.1/context",
 ) {
   const context = crate["@context"];

--- a/tests/zipService.test.ts
+++ b/tests/zipService.test.ts
@@ -1,5 +1,6 @@
+import assert from "assert";
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import type { ZipArchive, ZipFileEntry } from "../src/interfaces";
+import type { ZipArchive } from "../src/interfaces";
 import { testFileProvider, verifyCrateMetadataContext, type TestZipFile } from "./testUtils";
 
 describe("LocalZipService Implementation", async () => {
@@ -36,9 +37,9 @@ describe("ZipService.extractFile", () => {
       const testFile = await testFileProvider.local("rocrate-test.zip");
       const zipService = testFile.zipService;
       const zipArchive = await zipService.open();
-      const directory = zipArchive.entries.find((entry) => entry.type === "Directory") as ZipFileEntry;
+      const directory = zipArchive.entries.find((entry) => entry.type === "Directory");
 
-      expect(directory).toBeDefined();
+      assert(directory, "No directory found in the ZIP archive");
       await expect(zipService.extractFile(directory)).rejects.toThrow("Cannot extract a directory");
     } finally {
       consoleErrorSpy.mockRestore();

--- a/tests/zipService.test.ts
+++ b/tests/zipService.test.ts
@@ -37,7 +37,7 @@ describe("ZipService.extractFile", () => {
       const testFile = await testFileProvider.local("rocrate-test.zip");
       const zipService = testFile.zipService;
       const zipArchive = await zipService.open();
-      const directory = [...zipArchive.entries.values()].find((entry) => entry.type === "Directory");
+      const directory = zipArchive.findEntry((entry) => entry.type === "Directory");
 
       assert(directory, "No directory found in the ZIP archive");
       await expect(zipService.extractFile(directory)).rejects.toThrow("Cannot extract a directory");

--- a/tests/zipService.test.ts
+++ b/tests/zipService.test.ts
@@ -37,7 +37,7 @@ describe("ZipService.extractFile", () => {
       const testFile = await testFileProvider.local("rocrate-test.zip");
       const zipService = testFile.zipService;
       const zipArchive = await zipService.open();
-      const directory = zipArchive.entries.find((entry) => entry.type === "Directory");
+      const directory = [...zipArchive.entries.values()].find((entry) => entry.type === "Directory");
 
       assert(directory, "No directory found in the ZIP archive");
       await expect(zipService.extractFile(directory)).rejects.toThrow("Cannot extract a directory");
@@ -59,13 +59,13 @@ const testZipService = (zipTestFile: TestZipFile) => {
   describe("zipArchive", () => {
     describe("listFiles", () => {
       it("should return a list with all the files and directories contained in the remote Zip archive", () => {
-        expect(zipArchive.entries.length).toBe(expectations.entriesCount);
+        expect(zipArchive.entries.size).toBe(expectations.entriesCount);
       });
     });
 
     describe("extractFile", () => {
       it("should decompress and return the content of the file in the remote Zip archive", async () => {
-        expect(zipArchive.entries.length).toBeGreaterThan(0);
+        expect(zipArchive.entries.size).toBeGreaterThan(0);
         const remoteMetadataFile = zipArchive.findFileByName("ro-crate-metadata.json");
 
         if (!remoteMetadataFile) {


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality and robustness of the `ZipExplorer` and related classes. The key changes focus on improving error handling, updating data structures, and refining the testing framework.

### Enhancements to `ZipExplorer` and related classes:

* [`src/explorer.ts`](diffhunk://#diff-cf4fed4f071ae37f7edbfd697e282249fd322640b49fd67f6983d64ce8fbd8b9L25-R37): Added a new `entries` getter method to the `ZipExplorer` class to provide a map of file names to their corresponding file information objects. Introduced a `ensureZipArchiveOpen` method to handle cases where the ZIP archive is not opened before accessing its contents. [[1]](diffhunk://#diff-cf4fed4f071ae37f7edbfd697e282249fd322640b49fd67f6983d64ce8fbd8b9L25-R37) [[2]](diffhunk://#diff-cf4fed4f071ae37f7edbfd697e282249fd322640b49fd67f6983d64ce8fbd8b9R51-R57)

* [`src/interfaces.ts`](diffhunk://#diff-2ee8da4ec0f3c043c7e097851af07383ae3ce13022973c8727312e06bf2b89b3L49-R53): Updated the `ZipArchive` interface to use a map for `entries` instead of an array, and added a new method `findEntry` to locate entries based on specific criteria. [[1]](diffhunk://#diff-2ee8da4ec0f3c043c7e097851af07383ae3ce13022973c8727312e06bf2b89b3L49-R53) [[2]](diffhunk://#diff-2ee8da4ec0f3c043c7e097851af07383ae3ce13022973c8727312e06bf2b89b3R74-R81)

* [`src/zip/zipService.ts`](diffhunk://#diff-883a0632a838928476074d8731c53c3a3416b5defb0b12bc09833c1db1411ae0L37-R54): Modified the `AbstractZipService` class to return a map of ZIP file entries and implemented the `findEntry` method to support the new interface. [[1]](diffhunk://#diff-883a0632a838928476074d8731c53c3a3416b5defb0b12bc09833c1db1411ae0L37-R54) [[2]](diffhunk://#diff-883a0632a838928476074d8731c53c3a3416b5defb0b12bc09833c1db1411ae0L101-R129)

### Testing improvements:

* [`tests/explorer.test.ts`](diffhunk://#diff-1066213ef212cdfdbe29d431be81bff7f0e91480da48e66e3917a0b1754f7ce1R24-R29): Added new test cases to ensure proper error handling when accessing entries before the ZIP archive is opened and to verify the correct number of entries in the ZIP archive. [[1]](diffhunk://#diff-1066213ef212cdfdbe29d431be81bff7f0e91480da48e66e3917a0b1754f7ce1R24-R29) [[2]](diffhunk://#diff-1066213ef212cdfdbe29d431be81bff7f0e91480da48e66e3917a0b1754f7ce1R69-R79)

* [`tests/zipService.test.ts`](diffhunk://#diff-b4daf416a13ac4f3b7a523e5d4dc9621624622a04e6972f41cbfb7257f803a0aL39-R42): Updated tests to reflect changes in the `ZipArchive` interface, ensuring that the correct number of entries is checked using the new map structure. [[1]](diffhunk://#diff-b4daf416a13ac4f3b7a523e5d4dc9621624622a04e6972f41cbfb7257f803a0aL39-R42) [[2]](diffhunk://#diff-b4daf416a13ac4f3b7a523e5d4dc9621624622a04e6972f41cbfb7257f803a0aL61-R68)

### Miscellaneous:

* [`tests/testUtils.ts`](diffhunk://#diff-dec625688169f79383d0105ec3baf54c31d0f9dd06a84e006ba46e7be04571abL105-R106): Adjusted the `verifyCrateMetadataContext` function to accept `ROCrateImmutableView` in addition to `Record<string, unknown>`.