### PR TITLE
Improve file metadata

### DIFF
--- a/.changeset/evil-drinks-raise.md
+++ b/.changeset/evil-drinks-raise.md
@@ -1,0 +1,7 @@
+---
+"ro-crate-zip-explorer": patch
+---
+
+Improve file metadata
+
+Updated ZipEntryMetadata to include additional metadata fields for enhanced file information.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,12 @@
 export { isFileEntry, isRemoteZip } from "./utils.js";
 
 export { AbstractZipExplorer, ROCrateZipExplorer, ZipExplorer } from "./explorer.js";
-export type { AnyZipEntry, IZipExplorer, ZipArchive, ZipDirectoryEntry, ZipFileEntry } from "./interfaces.js";
+export type {
+  AnyZipEntry,
+  IZipExplorer,
+  ZipArchive,
+  ZipDirectoryEntry,
+  ZipEntryMetadata,
+  ZipFileEntry,
+} from "./interfaces.js";
 export type { Entity as ROCrateEntity, ROCrateImmutableView } from "./types/ro-crate-interfaces.js";

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -45,15 +45,43 @@ export interface IZipExplorer extends IFileMetadataProvider {
 }
 
 /**
- * Represents metadata associated with a file in a ZIP archive.
+ * Represents the basic metadata associated with a file.
+ *
+ * This information is typically extracted from the file system or
+ * from the metadata provided by the explorer.
+ * See {@link IFileMetadataProvider} for more details.
  */
-export interface FileMetadata {
-  /** The name of the file. */
-  name: string;
+interface BasicFileMetadata {
+  /**
+   * The displayable name of the file.
+   * This is typically the file name without the path or extension.
+   */
+  readonly name: string;
+
   /** The size of the file in bytes. */
-  size: number;
+  readonly size: number;
+
+  /** The date and time when the file was last modified. */
+  readonly dateTime: Date;
+
   /** An optional description of the file. */
-  description?: string;
+  readonly description?: string;
+}
+
+/**
+ * Contains metadata associated with a file in a ZIP archive.
+ */
+export interface ZipEntryMetadata extends BasicFileMetadata {
+  /**
+   * The full path of the file in the ZIP archive.
+   *
+   * @remarks
+   * **Serves as a unique identifier for the file within the archive.**
+   */
+  readonly path: string;
+
+  /** The associated zip entry information for this file in the ZIP archive. */
+  readonly entry: ZipFileEntry;
 }
 
 /**
@@ -77,7 +105,7 @@ export interface IFileMetadataProvider {
    * @returns The extracted metadata for the file entry.
    * @throws Throws an error if the metadata cannot be extracted.
    */
-  getFileEntryMetadata(entry: ZipFileEntry): FileMetadata;
+  getFileEntryMetadata(entry: ZipFileEntry): ZipEntryMetadata;
 }
 
 /**

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -70,6 +70,10 @@ interface BasicFileMetadata {
 
 /**
  * Contains metadata associated with a file in a ZIP archive.
+ *
+ * This metadata is extracted from the file system or
+ * from the metadata provided by the explorer.
+ * See {@link IFileMetadataProvider} for more details.
  */
 export interface ZipEntryMetadata extends BasicFileMetadata {
   /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -147,3 +147,16 @@ export function isRemoteZip(source: ZipSource): source is string {
 export function isFileEntry(entry?: AnyZipEntry): entry is ZipFileEntry {
   return entry !== undefined && entry.type === "File";
 }
+
+/**
+ * Combines two objects, merging properties from the source into the target.
+ * If a property in the source is `undefined`, it will be ignored.
+ * @param target - The target object to merge properties into.
+ * @param source - The source object to merge properties from.
+ * @returns The merged object with properties from both target and source.
+ */
+export function combineDefined<T extends object>(target: T, source: Partial<T>): T {
+  // Merge the properties of source into target ignoring undefined values
+  const definedSource = Object.fromEntries(Object.entries(source).filter(([, value]) => value !== undefined));
+  return { ...target, ...definedSource };
+}

--- a/tests/explorer.test.ts
+++ b/tests/explorer.test.ts
@@ -87,7 +87,6 @@ const testExplorerWithFile = (zipTestFile: TestZipFile) => {
   beforeAll(async () => {
     explorer = new ZipExplorer(zipTestFile.source);
     await explorer.open();
-    await explorer.extractMetadata();
   });
 
   describe("open", () => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { ZipDirectoryEntry, ZipFileEntry } from "../src";
 import type { ZipSource } from "../src/interfaces";
 import {
+  combineDefined,
   ensureUrlSupportsRanges,
   followRedirects,
   getRange,
@@ -213,5 +214,38 @@ describe("isRemoteZip", () => {
   it("should return false for a local file path", () => {
     const source: ZipSource = new File([], "file.zip");
     expect(isRemoteZip(source)).toBe(false);
+  });
+});
+
+describe("combineDefined", () => {
+  it("should merge properties from source into target", () => {
+    const target = { a: 1, b: 2 };
+    const source = { b: 3, c: 4 };
+    const result = combineDefined(target, source);
+    expect(result).toEqual({ a: 1, b: 3, c: 4 });
+  });
+
+  it("should ignore undefined properties in the source", () => {
+    const target = { a: 1, b: 2 };
+    const source = { b: undefined, c: 4 };
+    const result = combineDefined(target, source);
+    expect(result).toEqual({ a: 1, b: 2, c: 4 });
+  });
+
+  it("should return the target if the source is empty", () => {
+    const target = { a: 1, b: 2 };
+    const source = {};
+    const result = combineDefined(target, source);
+    expect(result).toEqual(target);
+  });
+
+  it("should return a new object without modifying the original target or source", () => {
+    const target = { a: 1, b: 2 };
+    const source = { b: 3, c: 4 };
+    const result = combineDefined(target, source);
+    expect(result).not.toBe(target);
+    expect(result).not.toBe(source);
+    expect(target).toEqual({ a: 1, b: 2 });
+    expect(source).toEqual({ b: 3, c: 4 });
   });
 });


### PR DESCRIPTION
This pull request includes several changes to the `src/explorer.ts` file and related files to improve metadata handling for ZIP entries. The most important changes include replacing `FileMetadata` with `ZipEntryMetadata`, adding a new utility function `combineDefined`, and updating the tests accordingly.

### Metadata Handling Improvements:
* Replaced `FileMetadata` with `ZipEntryMetadata` in `AbstractFileMetadataProvider` and related methods to provide more detailed metadata for ZIP entries. [[1]](diffhunk://#diff-cf4fed4f071ae37f7edbfd697e282249fd322640b49fd67f6983d64ce8fbd8b9L25-R26) [[2]](diffhunk://#diff-cf4fed4f071ae37f7edbfd697e282249fd322640b49fd67f6983d64ce8fbd8b9L43-R44) [[3]](diffhunk://#diff-cf4fed4f071ae37f7edbfd697e282249fd322640b49fd67f6983d64ce8fbd8b9L81-R82) [[4]](diffhunk://#diff-cf4fed4f071ae37f7edbfd697e282249fd322640b49fd67f6983d64ce8fbd8b9L93-R101) [[5]](diffhunk://#diff-cf4fed4f071ae37f7edbfd697e282249fd322640b49fd67f6983d64ce8fbd8b9L110-R118) [[6]](diffhunk://#diff-cf4fed4f071ae37f7edbfd697e282249fd322640b49fd67f6983d64ce8fbd8b9L284-R282)
* Updated the `interfaces.ts` file to define `ZipEntryMetadata` and `BasicFileMetadata`, providing a clearer structure for metadata. [[1]](diffhunk://#diff-2ee8da4ec0f3c043c7e097851af07383ae3ce13022973c8727312e06bf2b89b3L48-R88) [[2]](diffhunk://#diff-2ee8da4ec0f3c043c7e097851af07383ae3ce13022973c8727312e06bf2b89b3L80-R112)

### Export Updates:
* Updated exports in `index.ts` to include `ZipEntryMetadata` and other related types, ensuring they are available for use in other modules.
